### PR TITLE
Fix bug: Vec.cross miscalculates due to directly modifying one of its input

### DIFF
--- a/src/types/vec/vec.zig
+++ b/src/types/vec/vec.zig
@@ -698,9 +698,10 @@ fn SignedNumericVec3Mixin(comptime Self: type, comptime Dimens: comptime_int, co
             /// Modifies vector itself so that it is a cross product of vectors, i.e. a vector that is perpendicular to the plane
             /// containing x and y and has a magnitude that is equal to the area of the parallelogram that x and y span.
             pub fn crossSelf(a: *Self, b: Self) void {
-                a.x = a.y * b.z - a.z * b.y;
-                a.y = a.z * b.x - a.x * b.z;
-                a.z = a.x * b.y - a.y * b.x;
+                const a2 = a;
+                a.x = a2.y * b.z - a2.z * b.y;
+                a.y = a2.z * b.x - a2.x * b.z;
+                a.z = a2.x * b.y - a2.y * b.x;
             }
 
             /// Returns the cross product of the two input parameters, i.e. a vector that is perpendicular to the plane

--- a/src/types/vec/vec.zig
+++ b/src/types/vec/vec.zig
@@ -698,16 +698,17 @@ fn SignedNumericVec3Mixin(comptime Self: type, comptime Dimens: comptime_int, co
             /// Modifies vector itself so that it is a cross product of vectors, i.e. a vector that is perpendicular to the plane
             /// containing x and y and has a magnitude that is equal to the area of the parallelogram that x and y span.
             pub fn crossSelf(a: *Self, b: Self) void {
-                a = cross(a, b);
+                const a2 = a.*;
+                a.x = a2.y * b.z - a2.z * b.y;
+                a.y = a2.z * b.x - a2.x * b.z;
+                a.z = a2.x * b.y - a2.y * b.x;
             }
 
             /// Returns the cross product of the two input parameters, i.e. a vector that is perpendicular to the plane
             /// containing x and y and has a magnitude that is equal to the area of the parallelogram that x and y span.
             pub fn cross(a: Self, b: Self) Self {
-                var res = Self.new(0, 0, 0);
-                res.x = a.y * b.z - a.z * b.y;
-                res.y = a.z * b.x - a.x * b.z;
-                res.z = a.x * b.y - a.y * b.x;
+                var res = a;
+                res.crossSelf(b);
                 return res;
             }
         }

--- a/src/types/vec/vec.zig
+++ b/src/types/vec/vec.zig
@@ -698,17 +698,16 @@ fn SignedNumericVec3Mixin(comptime Self: type, comptime Dimens: comptime_int, co
             /// Modifies vector itself so that it is a cross product of vectors, i.e. a vector that is perpendicular to the plane
             /// containing x and y and has a magnitude that is equal to the area of the parallelogram that x and y span.
             pub fn crossSelf(a: *Self, b: Self) void {
-                const a2 = a;
-                a.x = a2.y * b.z - a2.z * b.y;
-                a.y = a2.z * b.x - a2.x * b.z;
-                a.z = a2.x * b.y - a2.y * b.x;
+                a = cross(a, b);
             }
 
             /// Returns the cross product of the two input parameters, i.e. a vector that is perpendicular to the plane
             /// containing x and y and has a magnitude that is equal to the area of the parallelogram that x and y span.
             pub fn cross(a: Self, b: Self) Self {
-                var res = a;
-                res.crossSelf(b);
+                var res = Self.new(0, 0, 0);
+                res.x = a.y * b.z - a.z * b.y;
+                res.y = a.z * b.x - a.x * b.z;
+                res.z = a.x * b.y - a.y * b.x;
                 return res;
             }
         }

--- a/test/vec.zig
+++ b/test/vec.zig
@@ -2173,6 +2173,11 @@ test "Vec.faceforward(...)" {
     try testing.expect(vec4f32_ff.x == ori4f32.x and vec4f32_ff.y == ori4f32.y and vec4f32_ff.z == ori4f32.z and vec4f32_ff.w == ori4f32.w);
 }
 
+test "Vec3.cross(...)" {
+    const vec3f32_cross = Vec3(f32).new(1, 0, 0).cross(Vec3(f32).new(0, 1, 0));
+    try testing.expect(vec3f32_cross.x == 0 and vec3f32_cross.y == 0 and vec3f32_cross.z == 1);
+}
+
 test "Vec.div(...)" {
     const vec1f32_div = Vec1(f32).new(3).div(Vec1(f32).as(2));
     try testing.expect(vec1f32_div.x == 1.5);


### PR DESCRIPTION
I was performing a cross product between 2 vectors, but it kept outputing the wrong answer.  
I checked and analyzed; The math is correct, it checks out outside of the function, but not inside.

Then I figured it out: `crossSelf(a, b)` applies the values directly on `a`, which is being used to calculate the result *at the same time*.

The fix: Instead of `cross` calling `crossSelf`, `crossSelf` calls `cross`, while `cross` does the maths that new `res` variable.
